### PR TITLE
Fixes/fix calc cops

### DIFF
--- a/src/oemof/thermal/compression_heatpumps_and_chillers.py
+++ b/src/oemof/thermal/compression_heatpumps_and_chillers.py
@@ -66,6 +66,10 @@ def calc_cops(temp_high, temp_low, quality_grade, temp_threshold_icing=2,
 
 
     """
+
+    if mode is None:
+        raise AttributeError("Please specify mode. Must be 'chiller' or 'heat_pump'")
+
     # Make both lists (temp_low and temp_high) have the same length and
     # convert unit to Kelvin.
     length = max([len(temp_high), len(temp_low)])

--- a/src/oemof/thermal/compression_heatpumps_and_chillers.py
+++ b/src/oemof/thermal/compression_heatpumps_and_chillers.py
@@ -11,8 +11,8 @@ oemof-thermal/src/oemof/thermal/compression_heatpumps_and_chillers.py
 """
 
 
-def calc_cops(temp_high, temp_low, quality_grade, temp_threshold_icing=2,
-              consider_icing=False, factor_icing=None, mode=None):
+def calc_cops(temp_high, temp_low, quality_grade, mode, temp_threshold_icing=2,
+              consider_icing=False, factor_icing=None):
     r"""
     Calculates the Coefficient of Performance (COP) of heat pumps and chillers
     based on the Carnot efficiency (ideal process) and a scale-down factor.

--- a/src/oemof/thermal/compression_heatpumps_and_chillers.py
+++ b/src/oemof/thermal/compression_heatpumps_and_chillers.py
@@ -66,10 +66,6 @@ def calc_cops(temp_high, temp_low, quality_grade, temp_threshold_icing=2,
 
 
     """
-
-    if mode is None:
-        raise AttributeError("Please specify mode. Must be 'chiller' or 'heat_pump'")
-
     # Make both lists (temp_low and temp_high) have the same length and
     # convert unit to Kelvin.
     length = max([len(temp_high), len(temp_low)])


### PR DESCRIPTION
The default mode=None leads to an error if the user does not set mode. Thus, this PR moves it to the required parameters.