### PR TITLE
Correct path

### DIFF
--- a/docs/api/oemof-thermal.rst
+++ b/docs/api/oemof-thermal.rst
@@ -15,7 +15,7 @@ concentrating_solar_power module
 
 solar_thermal_collector module
 ==========================================================
-.. automodule:: oemof.solar_thermal_collector
+.. automodule:: oemof.thermal.solar_thermal_collector
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
Fixes wrong path in api/oemof-thermal.rst automodule. Related to #48 and #54 