### PR TITLE
Add warning for new loss attributes

### DIFF
--- a/docs/stratified_thermal_storage.rst
+++ b/docs/stratified_thermal_storage.rst
@@ -203,6 +203,17 @@ Finally, the parameters can be used to define a storage component.
         outflow_conversion_factor=1.
     )
 
+
+.. warning::
+
+   For this example to work as intended, please use the not yet released oemof branch
+
+   https://github.com/oemof/oemof/tree/v0.3
+
+   which contains the new attributes for GenericStorage, `fixed_losses_absolute` and
+   `fixed_losses_relative`. As soon as the feature in oemof is released, no extra steps
+   will be necessary to use them and this warning will be removed.
+
 The following figure shows a comparison of results of a common storage implementation using
 only a loss rate vs. the stratified thermal storage implementation
 (`source code

--- a/examples/stratified_thermal_storage/example_stratified_thermal_storage.py
+++ b/examples/stratified_thermal_storage/example_stratified_thermal_storage.py
@@ -1,3 +1,13 @@
+"""
+For this example to work as intended, please use the not yet released oemof branch
+
+https://github.com/oemof/oemof/tree/v0.3
+
+that contains the new attributes for GenericStorage, `fixed_losses_absolute` and
+`fixed_losses_relative`.
+
+"""
+
 import os
 import pandas as pd
 import numpy as np

--- a/examples/stratified_thermal_storage/example_stratified_thermal_storage_investment.py
+++ b/examples/stratified_thermal_storage/example_stratified_thermal_storage_investment.py
@@ -1,3 +1,13 @@
+"""
+For this example to work as intended, please use the not yet released oemof branch
+
+https://github.com/oemof/oemof/tree/v0.3
+
+that contains the new attributes for GenericStorage, `fixed_losses_absolute` and
+`fixed_losses_relative`.
+
+"""
+
 import os
 import pandas as pd
 import numpy as np

--- a/examples/stratified_thermal_storage/plots.py
+++ b/examples/stratified_thermal_storage/plots.py
@@ -1,3 +1,13 @@
+"""
+For this script to work as intended, please use the not yet released oemof branch
+
+https://github.com/oemof/oemof/tree/v0.3
+
+that contains the new attributes for GenericStorage, `fixed_losses_absolute` and
+`fixed_losses_relative`.
+
+"""
+
 import os
 import pandas as pd
 import matplotlib.pyplot as plt


### PR DESCRIPTION
The stratified thermal storage needs the attributes fixed_losses_relative and fixed_losses_absolute. They are not released yet, but will be, probably in the end of February.

The problem is that there will be no warning if you pass unknown parameters to a component in oemof. Calculations run through smoothly, but the parameters are ignored.

In this PR, I added warnings in the docs and the three examples. They can be removed once the new attributes are released. At that point, the minimum required oemof version for oemof.thermal should be adapted to v3.3.

Please tell me if you see another thing that can help. If not, let's merge this soon to warn potential users.