### PR TITLE
Add status badges to readme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,3 +48,6 @@ script:
 #  only:
 #  - branch_name1
 #  - branch_name2
+
+after_success:
+  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
 install:
   - pip install -r tests/test_requirements.txt
   - pip install -e .
+  - pip install coveralls
 
 # commands to run tests 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
 install:
   - pip install -r tests/test_requirements.txt
   - pip install -e .
+  - pip install pytest-cov
   - pip install coveralls
 
 # commands to run tests 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
 script:
   - flake8
   - pylint */*.py
-  - pytest
+  - pytest --cov=src/oemof/thermal
 #jobs:
 #  include:
 #    - stage: "Tests"                # naming the Tests stage

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,5 @@
+|badge_pypi| |badge_travis| |badge_docs| |badge_coverage| |link-latest-doi|
+
 #############
 oemof.thermal
 #############
@@ -74,3 +76,24 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+.. |badge_pypi| image:: https://badge.fury.io/py/oemof.thermal.svg
+    :target: https://badge.fury.io/py/oemof.thermal
+    :alt: PyPI version
+
+.. |badge_docs| image:: https://readthedocs.org/projects/oemof-thermal/badge/?version=stable
+    :target: https://oemof-thermal.readthedocs.io/en/stable/
+    :alt: Documentation status
+
+.. |badge_coverage| image:: https://coveralls.io/repos/github/oemof/oemof-thermal/badge.svg?branch=dev
+    :target: https://coveralls.io/github/oemof/oemof-thermal?branch=dev
+    :alt: Test coverage
+
+.. |badge_travis| image:: https://travis-ci.org/oemof/oemof.svg?branch=dev
+    :target: https://travis-ci.org/oemof/oemof-thermal
+    :alt: Build status
+
+.. |link-latest-doi| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3606385.svg
+    :target: https://doi.org/10.5281/zenodo.3606385
+    :alt: Zenodo DOI


### PR DESCRIPTION
This PR adds some badges to the readme, showing build status, docs build status, test coverage and zenodo DOI. The badges allow to quickly get some key information about the repo and are quite standard. Other badges can be included if necessary.