### PR TITLE
Correct default values in stratified_thermal_storage.py

### DIFF
--- a/src/oemof/thermal/stratified_thermal_storage.py
+++ b/src/oemof/thermal/stratified_thermal_storage.py
@@ -112,11 +112,13 @@ def calculate_capacities(
 
     heat_capacity: numeric
         Average specific heat capacity of storage medium [J/(kg*K)]
-        Default values calculated with CoolProp for a temperature of 80 °C as a simplifying assumption
+        Default values calculated with CoolProp for a temperature of 80 °C
+        as a simplifying assumption
 
     density : numeric
         Average density of storage medium [kg/m3]
-        Default values calculated with CoolProp for a temperature of 80 °C as a simplifying assumption
+        Default values calculated with CoolProp for a temperature of 80 °C
+        as a simplifying assumption
 
     Returns
     -------
@@ -182,11 +184,13 @@ def calculate_losses(
 
     heat_capacity: numeric
         Average specific heat capacity of storage medium [J/(kg*K)]
-        Default values calculated with CoolProp for a temperature of 80 °C as a simplifying assumption
+        Default values calculated with CoolProp for a temperature of 80 °C
+        as a simplifying assumption
 
     density : numeric
         Average density of storage medium [kg/m3]
-        Default values calculated with CoolProp for a temperature of 80 °C as a simplifying assumption
+        Default values calculated with CoolProp for a temperature of 80 °C
+        as a simplifying assumption
 
     Returns
     -------

--- a/src/oemof/thermal/stratified_thermal_storage.py
+++ b/src/oemof/thermal/stratified_thermal_storage.py
@@ -81,7 +81,7 @@ def calculate_storage_dimensions(height, diameter):
 
 
 def calculate_capacities(
-    volume, temp_h, temp_c, nonusable_storage_volume, heat_capacity=4196, density=971.6
+    volume, temp_h, temp_c, nonusable_storage_volume, heat_capacity=4195.52, density=971.803
 ):
     r"""
     Calculates the nominal storage capacity, minimum
@@ -112,9 +112,11 @@ def calculate_capacities(
 
     heat_capacity: numeric
         Average specific heat capacity of storage medium [J/(kg*K)]
+        Calculated with CoolProp at a constant temperature of 80 °C as a simplification
 
     density : numeric
         Average density of storage medium [kg/m3]
+        Calculated with CoolProp at a constant temperature of 80 °C as a simplification
 
     Returns
     -------
@@ -144,8 +146,8 @@ def calculate_losses(
     temp_c,
     temp_env,
     time_increment=1,
-    heat_capacity=4180,
-    density=971.78,
+    heat_capacity=4195.52,
+    density=971.803,
 ):
     r"""
     Calculates loss rate and fixed losses for a stratified thermal storage.
@@ -180,9 +182,11 @@ def calculate_losses(
 
     heat_capacity: numeric
         Average specific heat capacity of storage medium [J/(kg*K)]
+        Calculated with CoolProp at a constant temperature of 80 °C as a simplification
 
     density : numeric
         Average density of storage medium [kg/m3]
+        Calculated with CoolProp at a constant temperature of 80 °C as a simplification
 
     Returns
     -------

--- a/src/oemof/thermal/stratified_thermal_storage.py
+++ b/src/oemof/thermal/stratified_thermal_storage.py
@@ -112,11 +112,11 @@ def calculate_capacities(
 
     heat_capacity: numeric
         Average specific heat capacity of storage medium [J/(kg*K)]
-        Calculated with CoolProp at a constant temperature of 80 °C as a simplification
+        Default values calculated with CoolProp for a temperature of 80 °C as a simplifying assumption
 
     density : numeric
         Average density of storage medium [kg/m3]
-        Calculated with CoolProp at a constant temperature of 80 °C as a simplification
+        Default values calculated with CoolProp for a temperature of 80 °C as a simplifying assumption
 
     Returns
     -------
@@ -182,11 +182,11 @@ def calculate_losses(
 
     heat_capacity: numeric
         Average specific heat capacity of storage medium [J/(kg*K)]
-        Calculated with CoolProp at a constant temperature of 80 °C as a simplification
+        Default values calculated with CoolProp for a temperature of 80 °C as a simplifying assumption
 
     density : numeric
         Average density of storage medium [kg/m3]
-        Calculated with CoolProp at a constant temperature of 80 °C as a simplification
+        Default values calculated with CoolProp for a temperature of 80 °C as a simplifying assumption
 
     Returns
     -------


### PR DESCRIPTION
With this pull request the default values for the density and capacity are corrected in the functions 

- calculate_capacities() and 
- calculate_losses() 

in stratified_thermal_storage.py. As a simplification the values are calculated with CoolProp for a constant temperature of 80 °C.