### PR TITLE
Fixes/docstring csp facade

### DIFF
--- a/src/oemof/thermal/facades.py
+++ b/src/oemof/thermal/facades.py
@@ -345,6 +345,7 @@ class ParabolicTroughCollector(Transformer, Facade):
     aperture_area: numeric
         Specify the ares or size of the collector.
 
+
     See the API of csp_precalc in oemof.thermal.concentrating_solar_power for
     the other parameters.
 

--- a/src/oemof/thermal/facades.py
+++ b/src/oemof/thermal/facades.py
@@ -348,7 +348,8 @@ class ParabolicTroughCollector(Transformer, Facade):
     See the API of csp_precalc in oemof.thermal.concentrating_solar_power for
     the other parameters.
 
-    example:
+    Examples
+    --------
     >>> from oemof import solph
     >>> from oemof.thermal.facades import Collector
     >>> bth = solph.Bus(label='thermal_bus')
@@ -376,7 +377,7 @@ class ParabolicTroughCollector(Transformer, Facade):
     ...     temp_collector_outlet=500,
     ...     temp_amb=input_data['t_amb'],
     ...     irradiance=input_data['E_dir_hor']
-    )
+    ... )
     """
 
     def __init__(self, *args, **kwargs):

--- a/src/oemof/thermal/facades.py
+++ b/src/oemof/thermal/facades.py
@@ -351,10 +351,10 @@ class ParabolicTroughCollector(Transformer, Facade):
     Examples
     --------
     >>> from oemof import solph
-    >>> from oemof.thermal.facades import Collector
+    >>> from oemof.thermal.facades import ParabolicTroughCollector
     >>> bth = solph.Bus(label='thermal_bus')
     >>> bel = solph.Bus(label='electrical_bus')
-    >>> collector = Collector(
+    >>> collector = ParabolicTroughCollector(
     ...     label='solar_collector',
     ...     heat_bus=bth,
     ...     electrical_bus=bel,


### PR DESCRIPTION
The docstring of the ParabolicTroughCollector is not rendered correctly. This PR fixes that by completing the code example section and adding a new empty line to start a new section for the text (got the hint from this example https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).