### PR TITLE
Improve documentation of stratified thermal storage

### DIFF
--- a/docs/stratified_thermal_storage.rst
+++ b/docs/stratified_thermal_storage.rst
@@ -79,7 +79,7 @@ Because of the space that diffuser plates for charging/discharging take up, it i
 the storage can neither be fully charged nor discharged, which is parametrised as a minimal/maximal
 storage level (indicated by the dotted lines in Fig. 1).
 
-These parameters are part of the stratified thermal storage:
+These parameters are part of the stratified thermal storage module:
 
     ========================= ===================================== ==== ===========
     symbol                    attribute                             type explanation


### PR DESCRIPTION
The aim of the PR is to clearify in the docu text that the facade bases on GenericStorage and that all of its parameters can therefore also be used with the facade of the stratified thermal storage.

Addionally, the information could be added to the API if that appears usefull.