### PR TITLE
Fix formula in docs of compression heat pumps

### DIFF
--- a/src/oemof/thermal/compression_heatpumps_and_chillers.py
+++ b/src/oemof/thermal/compression_heatpumps_and_chillers.py
@@ -226,7 +226,7 @@ def calc_chiller_quality_grade(nominal_conditions):
     .. calc_chiller_quality_grade-equations:
 
         :math:`\eta =
-        \frac{\dot{Q}_\mathrm{chilled,nominal}}{\dot{Q}_\mathrm{hot,nominal}} /
+        \frac{\dot{Q}_\mathrm{chilled,nominal}}{P_\mathrm{el}} /
         \frac{T_\mathrm{high, nominal}}{T_\mathrm{high, nominal}
         - T_\mathrm{low, nominal}}`
 


### PR DESCRIPTION
The formula in the docs for the quality_grade calculation contains a mistake. Instead of Q_hot_nominal the nominal power consumtion has to be in the denominator.

PR is related to #139.