### PR TITLE
Use collector heat as max instead of fix

### DIFF
--- a/src/oemof/thermal/facades.py
+++ b/src/oemof/thermal/facades.py
@@ -489,7 +489,7 @@ class ParabolicTroughCollector(Transformer, Facade):
             label=self.label + "-inflow",
             outputs={
                 self: Flow(nominal_value=self.aperture_area,
-                           fix=self.collectors_heat)
+                           max=self.collectors_heat)
             },
         )
 
@@ -643,7 +643,7 @@ class SolarThermalCollector(Transformer, Facade):
             label=self.label + "-inflow",
             outputs={
                 self: Flow(nominal_value=self.aperture_area,
-                           fix=self.collectors_heat)
+                           max=self.collectors_heat)
             },
         )
 

--- a/tests/lp_files/csp_collector.lp
+++ b/tests/lp_files/csp_collector.lp
@@ -71,6 +71,6 @@ bounds
    0 <= flow(solar_collector_bus_heat_1) <= +inf
    0 <= flow(solar_collector_bus_heat_2) <= +inf
    0 <= flow(solar_collector_inflow_solar_collector_0) <= 0
-   0 <= flow(solar_collector_inflow_solar_collector_1) <= 75650.812223268411
+   0 <= flow(solar_collector_inflow_solar_collector_1) <= 75650.81222326828
    0 <= flow(solar_collector_inflow_solar_collector_2) <= 0
 end

--- a/tests/lp_files/csp_collector.lp
+++ b/tests/lp_files/csp_collector.lp
@@ -47,14 +47,17 @@ c_e_Transformer_relation(solar_collector_bus_el_bus_heat_2)_:
 
 c_e_Transformer_relation(solar_collector_solar_collector_inflow_bus_heat_0)_:
 -1.25 flow(solar_collector_bus_heat_0)
++1 flow(solar_collector_inflow_solar_collector_0)
 = 0
 
 c_e_Transformer_relation(solar_collector_solar_collector_inflow_bus_heat_1)_:
 -1.25 flow(solar_collector_bus_heat_1)
-= -75650.81222326828
++1 flow(solar_collector_inflow_solar_collector_1)
+= 0
 
 c_e_Transformer_relation(solar_collector_solar_collector_inflow_bus_heat_2)_:
 -1.25 flow(solar_collector_bus_heat_2)
++1 flow(solar_collector_inflow_solar_collector_2)
 = 0
 
 c_e_ONE_VAR_CONSTANT: 
@@ -67,4 +70,7 @@ bounds
    0 <= flow(solar_collector_bus_heat_0) <= +inf
    0 <= flow(solar_collector_bus_heat_1) <= +inf
    0 <= flow(solar_collector_bus_heat_2) <= +inf
+   0 <= flow(solar_collector_inflow_solar_collector_0) <= 0
+   0 <= flow(solar_collector_inflow_solar_collector_1) <= 75650.812223268411
+   0 <= flow(solar_collector_inflow_solar_collector_2) <= 0
 end

--- a/tests/lp_files/solar_thermal_collector.lp
+++ b/tests/lp_files/solar_thermal_collector.lp
@@ -72,5 +72,5 @@ bounds
    0 <= flow(solar_collector_bus_heat_2) <= +inf
    0 <= flow(solar_collector_inflow_solar_collector_0) <= 0
    0 <= flow(solar_collector_inflow_solar_collector_1) <= 14566.653922252568
-   0 <= flow(solar_collector_inflow_solar_collector_2) <= 35868.680625336958
+   0 <= flow(solar_collector_inflow_solar_collector_2) <= 35868.680625337023
 end

--- a/tests/lp_files/solar_thermal_collector.lp
+++ b/tests/lp_files/solar_thermal_collector.lp
@@ -47,15 +47,18 @@ c_e_Transformer_relation(solar_collector_bus_el_bus_heat_2)_:
 
 c_e_Transformer_relation(solar_collector_solar_collector_inflow_bus_heat_0)_:
 -1.0526315789473684 flow(solar_collector_bus_heat_0)
++1 flow(solar_collector_inflow_solar_collector_0)
 = 0
 
 c_e_Transformer_relation(solar_collector_solar_collector_inflow_bus_heat_1)_:
 -1.0526315789473684 flow(solar_collector_bus_heat_1)
-= -14566.653922252568
++1 flow(solar_collector_inflow_solar_collector_1)
+= 0
 
 c_e_Transformer_relation(solar_collector_solar_collector_inflow_bus_heat_2)_:
 -1.0526315789473684 flow(solar_collector_bus_heat_2)
-= -35868.680625337023
++1 flow(solar_collector_inflow_solar_collector_2)
+= 0
 
 c_e_ONE_VAR_CONSTANT: 
 ONE_VAR_CONSTANT = 1.0
@@ -67,4 +70,7 @@ bounds
    0 <= flow(solar_collector_bus_heat_0) <= +inf
    0 <= flow(solar_collector_bus_heat_1) <= +inf
    0 <= flow(solar_collector_bus_heat_2) <= +inf
+   0 <= flow(solar_collector_inflow_solar_collector_0) <= 0
+   0 <= flow(solar_collector_inflow_solar_collector_1) <= 14566.653922252568
+   0 <= flow(solar_collector_inflow_solar_collector_2) <= 35868.680625336958
 end


### PR DESCRIPTION
The solar thermal façades set their power gains as a fixed quantity.
This means, all of it has to go somewhere. It would prevents energy
systems from being unsolvable because of heat overproduction,
when it is seen as the maximum instead.