### PR TITLE
Fix/update storage warnings

### DIFF
--- a/docs/stratified_thermal_storage.rst
+++ b/docs/stratified_thermal_storage.rst
@@ -240,13 +240,9 @@ model it, you can do so by performing the necessary pre-calculations and using o
 
 .. warning::
 
-   For this example to work as intended, please use the not yet released oemof-solph branch
-
-   https://github.com/oemof/oemof-solph/tree/dev
-
-   which contains the new attributes for GenericStorage, `fixed_losses_absolute` and
-   `fixed_losses_relative`. As soon as the feature in oemof is released, no extra steps
-   will be necessary to use them and this warning will be removed.
+   For this example to work as intended, please use oemof-solph v0.4.0 or higher
+   to ensure that the GenericStorage has the attributes :py:attr:`fixed_losses_absolute` and
+   :py:attr:`fixed_losses_relative`.
 
 The following figure shows a comparison of results of a common storage implementation using
 only a loss rate vs. the stratified thermal storage implementation

--- a/examples/stratified_thermal_storage/plots.py
+++ b/examples/stratified_thermal_storage/plots.py
@@ -1,11 +1,7 @@
 """
-For this script to work as intended, please use the not yet released oemof branch
-
-https://github.com/oemof/oemof/tree/v0.3
-
-that contains the new attributes for GenericStorage, `fixed_losses_absolute` and
-`fixed_losses_relative`.
-
+For this script to work as intended, please use oemof-solph v0.4.0 or higher
+to ensure that the GenericStorage has the attributes
+`fixed_losses_absolute` and `fixed_losses_relative`.
 """
 
 import os

--- a/examples/stratified_thermal_storage/stratified_thermal_storage.py
+++ b/examples/stratified_thermal_storage/stratified_thermal_storage.py
@@ -1,11 +1,7 @@
 """
-For this example to work as intended, please use the not yet released oemof branch
-
-https://github.com/oemof/oemof/tree/v0.3
-
-that contains the new attributes for GenericStorage, `fixed_losses_absolute` and
-`fixed_losses_relative`.
-
+For this example to work as intended, please use oemof-solph v0.4.0 or higher
+to ensure that the GenericStorage has the attributes
+`fixed_losses_absolute` and `fixed_losses_relative`.
 """
 
 import os

--- a/examples/stratified_thermal_storage/stratified_thermal_storage_facade.py
+++ b/examples/stratified_thermal_storage/stratified_thermal_storage_facade.py
@@ -1,3 +1,9 @@
+"""
+For this example to work as intended, please use oemof-solph v0.4.0 or higher
+to ensure that the GenericStorage has the attributes
+`fixed_losses_absolute` and `fixed_losses_relative`.
+"""
+
 import os
 import sys
 import pandas as pd

--- a/examples/stratified_thermal_storage/stratified_thermal_storage_investment_option_1.py
+++ b/examples/stratified_thermal_storage/stratified_thermal_storage_investment_option_1.py
@@ -1,11 +1,7 @@
 """
-For this example to work as intended, please use the not yet released oemof branch
-
-https://github.com/oemof/oemof/tree/v0.3
-
-that contains the new attributes for GenericStorage, `fixed_losses_absolute` and
-`fixed_losses_relative`.
-
+For this example to work as intended, please use oemof-solph v0.4.0 or higher
+to ensure that the GenericStorage has the attributes
+`fixed_losses_absolute` and `fixed_losses_relative`.
 """
 
 import os

--- a/examples/stratified_thermal_storage/stratified_thermal_storage_investment_option_1_facade.py
+++ b/examples/stratified_thermal_storage/stratified_thermal_storage_investment_option_1_facade.py
@@ -1,3 +1,9 @@
+"""
+For this example to work as intended, please use oemof-solph v0.4.0 or higher
+to ensure that the GenericStorage has the attributes
+`fixed_losses_absolute` and `fixed_losses_relative`.
+"""
+
 import os
 import pandas as pd
 import numpy as np

--- a/examples/stratified_thermal_storage/stratified_thermal_storage_investment_option_2.py
+++ b/examples/stratified_thermal_storage/stratified_thermal_storage_investment_option_2.py
@@ -1,11 +1,7 @@
 """
-For this example to work as intended, please use the not yet released oemof branch
-
-https://github.com/oemof/oemof/tree/v0.3
-
-that contains the new attributes for GenericStorage, `fixed_losses_absolute` and
-`fixed_losses_relative`.
-
+For this example to work as intended, please use oemof-solph v0.4.0 or higher
+to ensure that the GenericStorage has the attributes
+`fixed_losses_absolute` and `fixed_losses_relative`.
 """
 
 import os

--- a/examples/stratified_thermal_storage/stratified_thermal_storage_investment_option_2_facade.py
+++ b/examples/stratified_thermal_storage/stratified_thermal_storage_investment_option_2_facade.py
@@ -1,3 +1,9 @@
+"""
+For this example to work as intended, please use oemof-solph v0.4.0 or higher
+to ensure that the GenericStorage has the attributes
+`fixed_losses_absolute` and `fixed_losses_relative`.
+"""
+
 import os
 import pandas as pd
 import numpy as np


### PR DESCRIPTION
This PR updates the warnings in the examples and the docs of stratified thermal storage. With oemof.solph v0.4 and oemof.thermal v0.0.3, everything should be fine. We decided to keep the warnings so that users that have older version still get noticed.