### PR TITLE
Fix equation of quality grade in docs

### DIFF
--- a/src/oemof/thermal/compression_heatpumps_and_chillers.py
+++ b/src/oemof/thermal/compression_heatpumps_and_chillers.py
@@ -227,7 +227,7 @@ def calc_chiller_quality_grade(nominal_conditions):
 
         :math:`\eta =
         \frac{\dot{Q}_\mathrm{chilled,nominal}}{P_\mathrm{el}} /
-        \frac{T_\mathrm{high, nominal}}{T_\mathrm{high, nominal}
+        \frac{T_\mathrm{low, nominal}}{T_\mathrm{high, nominal}
         - T_\mathrm{low, nominal}}`
 
     Parameters


### PR DESCRIPTION
This PR adjusts the equation of the quality grade for compression heat pumps and chillers in the documentation.

Related: Issue https://github.com/oemof/oemof-thermal/issues/139