### PR TITLE
Add a warning, if required arguments are missing

### DIFF
--- a/src/oemof/thermal/concentrating_solar_power.py
+++ b/src/oemof/thermal/concentrating_solar_power.py
@@ -153,8 +153,7 @@ def csp_precalc(lat, long, collector_tilt, collector_azimuth, cleanliness,
         warnings.warn(
             "Parameter c_2 is not used for loss method 'Andasol'")
 
-    if loss_method == 'Andasol' and (a_3 == 0 or a_4 == 0 or
-                                     a_5 == 0 or a_6 == 0):
+    if loss_method == 'Andasol' and (a_3 == 0 or a_4 == 0 or a_5 == 0 or a_6 == 0):
         warnings.warn(
             "Parameters a_3 to a_6 are required for loss method 'Andasol'")
 

--- a/src/oemof/thermal/concentrating_solar_power.py
+++ b/src/oemof/thermal/concentrating_solar_power.py
@@ -15,6 +15,7 @@ SPDX-License-Identifier: MIT
 import pvlib
 import pandas as pd
 import numpy as np
+import warnings
 
 
 def csp_precalc(lat, long, collector_tilt, collector_azimuth, cleanliness,
@@ -71,7 +72,8 @@ def csp_precalc(lat, long, collector_tilt, collector_azimuth, cleanliness,
         Thermal loss parameter 1. Required for both loss methods.
 
     c_2: numeric
-        Thermal loss parameter 2. Required for loss method 'Janotte'.
+        Thermal loss parameter 2. Required for loss method 'Janotte'. If loss
+        method 'Andasol' is used, set it to 0.
 
     temp_collector_inlet: numeric or series with length periods
         Collectors inlet temperature.
@@ -146,6 +148,15 @@ def csp_precalc(lat, long, collector_tilt, collector_azimuth, cleanliness,
     if irradiance_required not in kwargs:
         raise AttributeError(
             f"'{irradiance_required}' necessary for {irradiance_method} is not provided")
+
+    if loss_method == 'Andasol' and (c_2 != 0):
+        warnings.warn(
+            "Parameter c_2 is not used for loss method 'Andasol'")
+
+    if loss_method == 'Andasol' and (a_3 == 0 or a_4 == 0 or
+                                     a_5 == 0 or a_6 == 0):
+        warnings.warn(
+            "Parameters a_3 to a_6 are required for loss method 'Andasol'")
 
     irradiance = kwargs.get(irradiance_required)
 


### PR DESCRIPTION
This PR should solve Issue #101. There will be a warning, if required parameters are missing. It is a warning and not an error, if somebody wants to set parameters to 0 on purpose.