### PR TITLE
Name submodules in init

### DIFF
--- a/src/oemof/thermal/__init__.py
+++ b/src/oemof/thermal/__init__.py
@@ -1,11 +1,10 @@
 __version__ = '0.0.5dev'
 __project__ = 'oemof.thermal'
 
-from . import (absorption_heatpumps_and_chillers,
-               compression_heatpumps_and_chillers,
-               facades,
-               stratified_thermal_storage,
-               cogeneration,
-               concentrating_solar_power,
-               solar_thermal_collector)
-
+from . import absorption_heatpumps_and_chillers  # noqa: F401
+from . import compression_heatpumps_and_chillers  # noqa: F401
+from . import facades  # noqa: F401
+from . import stratified_thermal_storage  # noqa: F401
+from . import cogeneration  # noqa: F401
+from . import concentrating_solar_power  # noqa: F401
+from . import solar_thermal_collector  # noqa: F401

--- a/src/oemof/thermal/__init__.py
+++ b/src/oemof/thermal/__init__.py
@@ -1,2 +1,11 @@
 __version__ = '0.0.5dev'
 __project__ = 'oemof.thermal'
+
+from . import (absorption_heatpumps_and_chillers,
+               compression_heatpumps_and_chillers,
+               facades,
+               stratified_thermal_storage,
+               cogeneration,
+               concentrating_solar_power,
+               solar_thermal_collector)
+


### PR DESCRIPTION
For better compatibility, submodules shoud be named in the init.
Otherwise, the following is not possible:
```Python
    from oemof import thermal
    thermal.stratified_thermal_storage.calculate_losses(...)
```